### PR TITLE
Zero initialize xcl_world

### DIFF
--- a/xcl/xcl.c
+++ b/xcl/xcl.c
@@ -97,6 +97,7 @@ char* xcl_create_and_set(const char* str) {
 xcl_world xcl_world_single() {
 	int err;
 	xcl_world world;
+	memset(&world, 0, sizeof(xcl_world));
 	cl_uint num_platforms;
 
 	char *xcl_mode = getenv("XCL_EMULATION_MODE");


### PR DESCRIPTION
See https://trello.com/c/lpsV9qXX/155-error-during-simulation-of-histogram-array#comment-5b4c6e491de08affd7332c9c

The `char *bindir` field was being set to 0x1 through uninitialized stack, and cgo would later complain as it tried to grow the stack and adjust pointer.