### PR TITLE
Nonblocking runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILDER := $(shell echo "`git config user.name` <`git config user.email`>")
 PKG_RELEASE ?= 1
 PROJECT_URL := "https://github.com/ReconfigureIO/$(NAME)"
 
-.PHONY: test all clean
+.PHONY: test all clean compile
 
 CMD_SOURCES := $(shell go list ./... | grep /cmd/)
 TARGETS := $(patsubst github.com/ReconfigureIO/sdaccel/cmd/%,dist/%,$(CMD_SOURCES))
@@ -17,6 +17,9 @@ all: ${TARGETS}
 
 test:
 	go test -v $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
+
+compile:
+	LIBRARY_PATH=${XILINX_SDX}/runtime/lib/x86_64/:${XILINX_SDX}/SDK/lib/lnx64.o/:/usr/lib/x86_64-linux-gnu:${LIBRARY_PATH} CGO_CFLAGS=-I${XILINX_SDX}/runtime/include/1_2/ go build -tags opencl github.com/ReconfigureIO/sdaccel/xcl
 
 dist:
 	mkdir -p dist

--- a/xcl/fake.go
+++ b/xcl/fake.go
@@ -213,8 +213,8 @@ func (kernel *Kernel) SetArg(index uint, val uint32) {
 /*
 Run will start execution of the Kernel with the number of dimensions. Most uses of this should be called as
 
-    kernel.Run(1,1,1)
+    kernel.Run()
 
 */
-func (kernel *Kernel) Run(x, y, z uint) {
+func (kernel *Kernel) Run(_ ...uint) {
 }

--- a/xcl/xcl.go
+++ b/xcl/xcl.go
@@ -303,11 +303,28 @@ func (kernel *Kernel) SetArg(index uint, val uint32) {
 }
 
 /*
-Run will start execution of the Kernel with the number of dimensions. Most uses of this should be called as
+Run will start execution of the Kernel. Most uses of this should be called as
 
-    kernel.Run(1,1,1)
+    kernel.Run()
 
 */
-func (kernel *Kernel) Run(x, y, z uint) {
-	C.xcl_run_kernel3d(kernel.program.world.cw, kernel.kernel, C.size_t(x), C.size_t(y), C.size_t(z))
+func (kernel *Kernel) Run(_ ...uint) error {
+	size := C.size_t(0)
+	event := new(C.cl_event)
+
+	errCode := C.clEnqueueNDRangeKernel(kernel.program.world.cw.command_queue, krnl.kernel, 1,
+		nil, &size, &size, 0, nil, &event)
+
+	err := errorCode(errCode)
+
+	if err != nil {
+		return err
+	}
+
+	errCode = cl.WaitForEvents(1, *event)
+
+	err = errorCode(errCode)
+
+	return err
+
 }

--- a/xcl/xcl.go
+++ b/xcl/xcl.go
@@ -314,25 +314,18 @@ func (kernel *Kernel) Run(_ ...uint) error {
 
 	errCode := C.clEnqueueNDRangeKernel(kernel.program.world.cw.command_queue, kernel.kernel, 1,
 		nil, &size, &size, 0, nil, event)
-
 	err := errorCode(errCode)
-
 	if err != nil {
 		return err
 	}
 
 	errCode = C.clFlush(kernel.program.world.cw.command_queue)
-
 	err = errorCode(errCode)
-
 	if err != nil {
 		return err
 	}
 
 	errCode = C.clWaitForEvents(1, event)
-
 	err = errorCode(errCode)
-
 	return err
-
 }

--- a/xcl/xcl.go
+++ b/xcl/xcl.go
@@ -312,8 +312,8 @@ func (kernel *Kernel) Run(_ ...uint) error {
 	size := C.size_t(0)
 	event := new(C.cl_event)
 
-	errCode := C.clEnqueueNDRangeKernel(kernel.program.world.cw.command_queue, krnl.kernel, 1,
-		nil, &size, &size, 0, nil, &event)
+	errCode := C.clEnqueueNDRangeKernel(kernel.program.world.cw.command_queue, kernel.kernel, 1,
+		nil, &size, &size, 0, nil, event)
 
 	err := errorCode(errCode)
 
@@ -321,7 +321,7 @@ func (kernel *Kernel) Run(_ ...uint) error {
 		return err
 	}
 
-	errCode = cl.WaitForEvents(1, *event)
+	errCode = C.clWaitForEvents(1, event)
 
 	err = errorCode(errCode)
 

--- a/xcl/xcl.go
+++ b/xcl/xcl.go
@@ -321,6 +321,14 @@ func (kernel *Kernel) Run(_ ...uint) error {
 		return err
 	}
 
+	errCode = C.clFlush(kernel.program.world.cw.command_queue)
+
+	err = errorCode(errCode)
+
+	if err != nil {
+		return err
+	}
+
 	errCode = C.clWaitForEvents(1, event)
 
 	err = errorCode(errCode)

--- a/xcl/xcl.go
+++ b/xcl/xcl.go
@@ -309,7 +309,7 @@ Run will start execution of the Kernel. Most uses of this should be called as
 
 */
 func (kernel *Kernel) Run(_ ...uint) error {
-	size := C.size_t(0)
+	size := C.size_t(1)
 	event := new(C.cl_event)
 
 	errCode := C.clEnqueueNDRangeKernel(kernel.program.world.cw.command_queue, kernel.kernel, 1,


### PR DESCRIPTION
Right now, using `Kernel.Run` will block the entire work queue, preventing further allocations, transfers, etc. This is an attempt to fix that. 