### PR TITLE
Add workaround for legacy compiler channel looping bug.

### DIFF
--- a/smi/protocol.go
+++ b/smi/protocol.go
@@ -74,7 +74,8 @@ func ForwardFrame64(
 	forwardDone chan<- bool) {
 	smiBuffer := make(chan Flit64, 34 /* SmiMemFrame64Size */)
 
-	for <-forwardReq {
+	doForward := <-forwardReq
+	for doForward {
 		go func() {
 			hasNextInputFlit := true
 			for hasNextInputFlit {
@@ -91,6 +92,7 @@ func ForwardFrame64(
 			hasNextOutputFlit = outputFlitData.Eofc == uint8(0)
 		}
 		forwardDone <- true
+		doForward = <-forwardReq
 	}
 }
 
@@ -109,7 +111,8 @@ func AssembleFrame64(
 	assembleDone chan<- bool) {
 	smiBuffer := make(chan Flit64, 34 /* SmiMemFrame64Size */)
 
-	for <-assembleReq {
+	doAssemble := <-assembleReq
+	for doAssemble {
 		hasNextInputFlit := true
 		for hasNextInputFlit {
 			inputFlitData := <-smiInput
@@ -124,6 +127,7 @@ func AssembleFrame64(
 			hasNextOutputFlit = outputFlitData.Eofc == uint8(0)
 		}
 		assembleDone <- true
+		doAssemble = <-assembleReq
 	}
 }
 


### PR DESCRIPTION
The legacy compiler has a bug where loops of the form `for <-forwardReq {` only pop data from the channel on entering the loop and not on each subsequent iteration. This is a workaround for the bug which was breaking the SMI burst transaction library.