### PR TITLE
Avoid setting XCL_EMULATION_MODE to 'true'

### DIFF
--- a/xcl/xcl.c
+++ b/xcl/xcl.c
@@ -121,12 +121,6 @@ xcl_world xcl_world_single() {
 			 * XCL_EMULATION_MODE is set to */
 			world.mode = xcl_create_and_set(xcl_mode);
 		}
-
-		err = setenv("XCL_EMULATION_MODE", "true", 1);
-		if(err != 0) {
-			printf("Error: cannot set XCL_EMULATION_MODE\n");
-			exit(EXIT_FAILURE);
-		}
 	}
 
 	err = clGetPlatformIDs(0, NULL, &num_platforms);


### PR DESCRIPTION
Simluation was failing with the following error because internally we set the environment to 'true'. This is no longer supported on Xilinx SDx 2018.2. The error message it got was this:

```
ERROR: [SDx-EM 08] Please set XCL_EMULATION_MODE to "hw_emu" to run hardware emulation.
ERROR: [SDx-EM 09] Please set XCL_EMULATION_MODE to "sw_emu" to run software emulation.
ERROR: No devices found
Error: no platforms available or OpenCL install broken
```

Solution is to pass through the environment unmodified.